### PR TITLE
Samsung and Alfa updated

### DIFF
--- a/docs/pages/lab-equipment/hacking-tools.md
+++ b/docs/pages/lab-equipment/hacking-tools.md
@@ -12,8 +12,8 @@ The lab contains some equipment that can be used out-of-the-box for hacking.
 
 Device  | Misc | Availability
 ------------- | -------------
-[Ubertooth One](https://github.com/greatscottgadgets/ubertooth/wiki)  x2 | Can be used for [Bluetooth hacking](/pages/guides/bluetooth-mitm) | 2x borrowed <!--1x borrowed by Martin -->
-[ALFA Long-Range USB Adapter AWUS036NHA](https://www.alfa.com.tw/products_detail/7.htm) | Can be used for [Wi-Fi hacking](https://www.youtube.com/watch?v=e2ZzTZoZ4wg)  |  Available
+[Ubertooth One](https://github.com/greatscottgadgets/ubertooth/wiki)  x2 | Can be used for [Bluetooth hacking](/pages/guides/bluetooth-mitm) | 2x Borrowed <!--1x borrowed by Martin -->
+[ALFA Long-Range USB Adapter AWUS036NHA](https://www.alfa.com.tw/products_detail/7.htm) 1x | Can be used for [Wi-Fi hacking](https://www.youtube.com/watch?v=e2ZzTZoZ4wg)  | 1x Borrowed
 [ASUS Gigabit Router](https://www.asus.com/Networking/RT-AC1900P/)    | A powerful router that can be used for a number of tasks such as [Wi-Fi hacking](/pages/guides/wifi-mitm). Used as lab's Wi-Fi.  | Available
 [WiFi Pineapple Tetra, Model 5.8](https://shop.hak5.org/products/wifi-pineapple) x1   | - | Available
 [HackRF One](https://greatscottgadgets.com/hackrf/one/) x3   | - | 3x Borrowed <!-- Martin Hilding -->

--- a/docs/pages/lab-equipment/iot-devices.md
+++ b/docs/pages/lab-equipment/iot-devices.md
@@ -85,7 +85,7 @@ Device  | Availability
 
 Device | Availability
 ------------- | -------------
-[Samsung Galaxy A41](https://www.samsung.com/se/smartphones/galaxy-a/galaxy-a41-black-64gb-sm-a415fzkdeud/) 1x | Available
+[Samsung Galaxy A41](https://www.samsung.com/se/smartphones/galaxy-a/galaxy-a41-black-64gb-sm-a415fzkdeud/) 1x | 1x Borrowed
 
 ## ICS equipment
 


### PR DESCRIPTION
Changed status Samsung A41 and ALFA Long-range. Also changed "borrowed" to "Borrowed" for consistency for Ubertooth One.