### PR TITLE
Add CVE Reporting Form page in Hacking Guides

### DIFF
--- a/docs/pages/guides/cve-reporting.md
+++ b/docs/pages/guides/cve-reporting.md
@@ -1,0 +1,31 @@
+---
+title: Reporting CVEs
+parent: Hacking Guides
+has_children: false
+nav_order: 10
+---
+
+# CVE Reporting
+
+
+Have you found any interesting threats during your research at KTH?
+If so, you can report it using the following Form so that we can collect it on the department's webpage along with other interesting findings. To do that, you need to have done a responsible disclosure and have a CVE ID. If you haven't done that yet, you can perform this process following the guide on [Responsible Disclosure](https://nse.digital/pages/thesis_guidelines/responsible_disclosure.html).
+
+For reporting the CVE, you need to provide a short description of the vulnerabiliy as in the following example from our [CVE List](https://www.kth.se/cs/nse/research/software-systems-architecture-and-security/projects/ethical-hacking-1.914053):
+
+<dl>
+  <dt>CVE-2020-12282</dt>
+  <dd>
+    iSmartgate PRO 1.5.9 is vulnerable to CSRF via the busca parameter in the form used for searching for users, accessible via /index.php. (This can be combined with reflected XSS.)
+    <br>
+    <i><b>Student</b></i>: Madeleine Berner<br>
+    <i><b>Supervisor</b></i>: Pontus Johnson<br>
+    <i><b>Examiner</b></i>: Robert Lagerström
+  </dd>
+</dl>
+
+Once having a CVE identifier, you can send us the details for its publication by filling the following form:
+
+<a href="https://forms.gle/V24PrVUCUVi9nvxH7" style="width: 100%; display: block;">
+    <button style="font-size: 15px; padding: 4px; margin: 0 auto; border: 1px solid rgb(145, 145, 145); max-width: 180px; border-radius: 4px; background-color: transparent; color: white; display: inherit; height: 45px; width: 150px"><a href="https://forms.gle/V24PrVUCUVi9nvxH7">CVE Reporting form</a></button>
+</a>


### PR DESCRIPTION
As requested by @fredrik010, this pull request adds a new page with information and a form link for recollecting CVEs for their posterior publication on NSE's web pages.